### PR TITLE
Move R to common code, create R versions of all python scripts, add in missingness customizability

### DIFF
--- a/code/R/dqaf_metrics.R
+++ b/code/R/dqaf_metrics.R
@@ -28,7 +28,7 @@ calculate_proportion <- function(death_records, metric, metric_description){
 }
 
 # Calculate the proportion of the provided metric for each distinct value in supplied column
-calculate_proportion_by_column <- function(death_records, metric, metric_description, column){
+calculate_proportion_by_column <- function(death_records, metric, column){
   col_proportions <- 
     aggregate(
       list("Proportion" = death_records[, metric]),
@@ -39,17 +39,8 @@ calculate_proportion_by_column <- function(death_records, metric, metric_descrip
     col_proportions[order(col_proportions$Proportion, decreasing = T),]
   colnames(col_proportions) <- c(column, "Proportion")
   
-  
   # Print the proportions for each of the columns
-  for(i in 1:nrow(col_proportions)) {
-    cat(paste(
-      "The proportion of records with",
-      metric_description,
-      "by",
-      col_proportions[i, column],
-      "is",
-      round(col_proportions[i, "Proportion"], 2), "\n"))
-  }
+  print(col_proportions)
   
   return(col_proportions)
 }

--- a/code/R/dqaf_metrics.R
+++ b/code/R/dqaf_metrics.R
@@ -46,7 +46,7 @@ calculate_proportion_by_column <- function(death_records, metric, metric_descrip
       "The proportion of records with a(n)",
       metric_description,
       "by",
-      column,
+      col_proportions[i, column],
       "is",
       round(col_proportions[i, "Proportion"], 2), "\n"))
   }

--- a/code/R/dqaf_metrics.R
+++ b/code/R/dqaf_metrics.R
@@ -20,7 +20,7 @@ calculate_proportion <- function(death_records, metric, metric_description){
   proportion <- mean(death_records[, metric], na.rm = TRUE)
   
   cat(paste(
-    "The proportion of records with a(n)", metric_description, "is",
+    "The proportion of records with", metric_description, "is",
     round(proportion, 2),
     "\n"))
   
@@ -43,7 +43,7 @@ calculate_proportion_by_column <- function(death_records, metric, metric_descrip
   # Print the proportions for each of the columns
   for(i in 1:nrow(col_proportions)) {
     cat(paste(
-      "The proportion of records with a(n)",
+      "The proportion of records with",
       metric_description,
       "by",
       col_proportions[i, column],

--- a/code/R/dqaf_metrics.R
+++ b/code/R/dqaf_metrics.R
@@ -16,19 +16,25 @@ load_death_records <- function(file){
 }
 
 # Calculate and print the overall proportion of the provided metric on the records we loaded above
-calculate_proportion <- function(death_records, metric, metric_description){
+calculate_proportion <- function(
+    death_records, metric, metric_description, print_output = TRUE
+  ){
   proportion <- mean(death_records[, metric], na.rm = TRUE)
   
-  cat(paste(
-    "The proportion of records with", metric_description, "is",
-    round(proportion, 2),
-    "\n"))
+  if (print_output){
+    cat(paste(
+      "The proportion of records with", metric_description, "is",
+      round(proportion, 2),
+      "\n"))
+  }
   
   return(proportion)
 }
 
 # Calculate the proportion of the provided metric for each distinct value in supplied column
-calculate_proportion_by_column <- function(death_records, metric, column){
+calculate_proportion_by_column <- function(
+    death_records, metric, column, print_output = TRUE
+  ){
   col_proportions <- 
     aggregate(
       list("Proportion" = death_records[, metric]),
@@ -39,8 +45,10 @@ calculate_proportion_by_column <- function(death_records, metric, column){
     col_proportions[order(col_proportions$Proportion, decreasing = T),]
   colnames(col_proportions) <- c(column, "Proportion")
   
-  # Print the proportions for each of the columns
-  print(col_proportions)
+  if (print_output){
+    # Print the proportions for each of the columns
+    print(col_proportions)
+  }
   
   return(col_proportions)
 }

--- a/code/R/dqaf_metrics.R
+++ b/code/R/dqaf_metrics.R
@@ -1,0 +1,55 @@
+# Common Code Across R functions
+
+# functions for support ----
+
+# Use supplied path to records and load as a pandas dataframe
+load_death_records <- function(file){
+  # Load the death records data
+  death_records <- read.csv(
+    file,
+    stringsAsFactors = FALSE,
+    check.names = FALSE,
+    na.strings = ""
+  )
+  
+  return(death_records)
+}
+
+# Calculate and print the overall proportion of the provided metric on the records we loaded above
+calculate_proportion <- function(death_records, metric, metric_description){
+  proportion <- mean(death_records[, metric], na.rm = TRUE)
+  
+  cat(paste(
+    "The proportion of records with a(n)", metric_description, "is",
+    round(proportion, 2),
+    "\n"))
+  
+  return(proportion)
+}
+
+# Calculate the proportion of the provided metric for each distinct value in supplied column
+calculate_proportion_by_column <- function(death_records, metric, metric_description, column){
+  col_proportions <- 
+    aggregate(
+      list("Proportion" = death_records[, metric]),
+      list("Output" = death_records[, column]),
+      FUN = mean,
+      na.rm = TRUE)
+  col_proportions <- 
+    col_proportions[order(col_proportions$Proportion, decreasing = T),]
+  colnames(col_proportions) <- c(column, "Proportion")
+  
+  
+  # Print the proportions for each of the columns
+  for(i in 1:nrow(col_proportions)) {
+    cat(paste(
+      "The proportion of records with a(n)",
+      metric_description,
+      "by",
+      column,
+      "is",
+      round(col_proportions[i, "Proportion"], 2), "\n"))
+  }
+  
+  return(col_proportions)
+}

--- a/code/R/proportion_not_certified_within_required_period.R
+++ b/code/R/proportion_not_certified_within_required_period.R
@@ -27,12 +27,14 @@ death_records[, "Not Within 5 Days"] <-
 proportion <- calculate_proportion(
   death_records, 
   metric = "Not Within 5 Days",
-  metric_description = "Date Certified is not within 5 days of the Date of Death"
+  metric_description = "Date Certified is not within 5 days of the Date of Death", 
+  print_output = TRUE
 )
 
 # Group the records by certifier and calculate the proportion of flagged records for each certifier
 certifier_proportions <- calculate_proportion_by_column(
   death_records, 
   metric = "Not Within 5 Days",
-  column = "Certifier Name"
+  column = "Certifier Name", 
+  print_output = TRUE
 )

--- a/code/R/proportion_not_certified_within_required_period.R
+++ b/code/R/proportion_not_certified_within_required_period.R
@@ -34,6 +34,5 @@ proportion <- calculate_proportion(
 certifier_proportions <- calculate_proportion_by_column(
   death_records, 
   metric = "Not Within 5 Days",
-  metric_description = "Date Certified is not within 5 days of the Date of Death",
   column = "Certifier Name"
 )

--- a/code/R/proportion_not_certified_within_required_period.R
+++ b/code/R/proportion_not_certified_within_required_period.R
@@ -2,16 +2,13 @@
 library(lubridate)
 library(here)
 
-# Specify the relative path to the data location
-data_path <- here::here("data")
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
 
 # Load the death records data
-death_records <- read.csv(
-  file.path(data_path, "SyntheticDeathRecordData.csv"),
-  stringsAsFactors = FALSE,
-  check.names = FALSE,
-  na.strings = ""
-)
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
 
 # Parse the dates
 death_records$`Date of Death` <- as.Date(death_records$`Date of Death`)
@@ -27,25 +24,16 @@ death_records[, "Not Within 5 Days"] <-
   death_records$`Days Difference` > 5
 
 # Calculate the proportion of records where the Date Certified is not within 5 days of the Date of Death
-proportion <- mean(death_records$`Not Within 5 Days`, na.rm = TRUE)
-
-cat(paste("Proportion of records where the Date Certified is not within 5 days of the Date of Death: ",
-          round(proportion, 2), "\n"))
+proportion <- calculate_proportion(
+  death_records, 
+  metric = "Not Within 5 Days",
+  metric_description = "Date Certified is not within 5 days of the Date of Death"
+)
 
 # Group the records by certifier and calculate the proportion of flagged records for each certifier
-certifier_proportions <- 
-  aggregate(
-    list("Proportion" = death_records$`Not Within 5 Days`),
-    list("Certifier Name" = death_records$`Certifier Name`),
-    FUN = mean,
-    na.rm = TRUE)
-certifier_proportions <- 
-  certifier_proportions[order(certifier_proportions$Proportion, decreasing = T),]
-
-# Print the proportions for each certifier
-for(i in 1:nrow(certifier_proportions)) {
-  cat(paste("The proportion of records where the Date Certified is not within 5 days of the Date of Death by",
-            certifier_proportions[i, "Certifier Name"],
-            "is",
-            round(certifier_proportions[i, "Proportion"], 2), "\n"))
-}
+certifier_proportions <- calculate_proportion_by_column(
+  death_records, 
+  metric = "Not Within 5 Days",
+  metric_description = "Date Certified is not within 5 days of the Date of Death",
+  column = "Certifier Name"
+)

--- a/code/R/proportion_with_incomplete_demographic.R
+++ b/code/R/proportion_with_incomplete_demographic.R
@@ -34,7 +34,7 @@ unknown_responses <- c(
 # blank value for the field and the proportion of records that have
 # an explicit "Unknown" value for the field
 for (field in demographic_fields){
-  cat(paste0("Evaluating fields matching ", field), "\n")
+  cat(paste0("  Evaluating fields matching ", field), "\n")
   
   # Find the columns that match this field (may be more than one if it's a regex)
   matching_columns <- if (!grepl("\\.\\*", field)){

--- a/code/R/proportion_with_incomplete_demographic.R
+++ b/code/R/proportion_with_incomplete_demographic.R
@@ -67,7 +67,8 @@ for (field in demographic_fields){
     proportion <- calculate_proportion(
       death_records, 
       metric = paste0("Blank ", mc),
-      metric_description = paste0("blank values for ", mc)
+      metric_description = paste0("blank values for ", mc), 
+      print_output = TRUE
     )
     
     # Now find the proportion that are "unknown"
@@ -77,7 +78,8 @@ for (field in demographic_fields){
     proportion <- calculate_proportion(
       death_records, 
       metric = paste0("Unknown ", mc),
-      metric_description = paste0("explicit 'unknown' values for ", mc)
+      metric_description = paste0("explicit 'unknown' values for ", mc), 
+      print_output = TRUE
     )
   }
   

--- a/code/R/proportion_with_incomplete_demographic.R
+++ b/code/R/proportion_with_incomplete_demographic.R
@@ -1,0 +1,81 @@
+# Load necessary libraries
+library(here)
+
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
+
+# Load the death records data
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
+
+# List of fields we want to check for individually
+demographic_fields = c(
+  "Age",
+  "County of Death",
+  "Date of Death",
+  "Education",
+  "Hispanic .*", # Match any field starting with 'Hispanic'
+  "Manner of Death",
+  "Place of Death",
+  "Pregnancy Status",
+  "Race .*", # Match any field starting with 'Race'
+  "Tobacco Use Contributed to Death"
+)
+
+
+# For each field we first check if the field is present in the data;
+# if it's present, we evaluate the proportion of records that have a
+# blank value for the field and the proportion of records that have
+# an explicit "Unknown" value for the field
+for (field in demographic_fields){
+  cat(paste0("Evaluating fields matching ", field), "\n")
+  
+  # Find the columns that match this field (may be more than one if it's a regex)
+  matching_columns <- if (!grepl("\\.\\*", field)){
+    colnames(death_records)[colnames(death_records) == field]
+  } else {
+    colnames(death_records)[grepl(field, colnames(death_records))]
+  }
+  
+  # Check if the field was found in the data
+  if (length(matching_columns) < 1){
+    cat(paste0("No columns matching ", field, " exist in the data", "\n"))
+    cat("\n")
+    next
+  }
+  
+  
+  # TODO: We need to special case pregnancy status; do it with a lambda in the fields list?
+  # TODO: Pregnancy has "No response", is that equivalent to unknown?
+  # TODO: Explore configuration file for e.g., what is "unknown", threshold for flagging certifiers, etc. (multiple tests could use common code)
+  # TODO: May need to consider "Not applicable" as well
+  # TODO: Pregnancy has "Unknown if pregnant within the past year", should we look for any match to an "Unknown" regex?
+  # TODO: Perhaps allow jurisdiction to configure which values mean "missing" and which "unknown"?
+  # TODO: Maybe field list lambda includes the check to use?
+  
+  for (mc in matching_columns){
+    # The field is present, so now find the proportion that are blank
+    death_records[, paste0("Blank ", mc)] <- 
+      as.numeric(is.na(death_records[, mc]))
+    
+    proportion <- calculate_proportion(
+      death_records, 
+      metric = paste0("Blank ", mc),
+      metric_description = paste0("blank values for ", mc)
+    )
+    
+    # Now find the proportion that are "unknown"
+    death_records[, paste0("Unknown ", mc)] <- 
+      as.numeric(grepl("Unknown", death_records[, mc]) |
+                   grepl("U", death_records[, mc]))
+    
+    proportion <- calculate_proportion(
+      death_records, 
+      metric = paste0("Unknown ", mc),
+      metric_description = paste0("explicit 'unknown' values for ", mc)
+    )
+  }
+  
+  cat("\n")
+}

--- a/code/R/proportion_with_incomplete_demographic.R
+++ b/code/R/proportion_with_incomplete_demographic.R
@@ -23,6 +23,11 @@ demographic_fields = c(
   "Tobacco Use Contributed to Death"
 )
 
+# Define responses corresponding to "unknown"
+unknown_responses <- c(
+  "Unknown",
+  "U"
+)
 
 # For each field we first check if the field is present in the data;
 # if it's present, we evaluate the proportion of records that have a
@@ -67,8 +72,7 @@ for (field in demographic_fields){
     
     # Now find the proportion that are "unknown"
     death_records[, paste0("Unknown ", mc)] <- 
-      as.numeric(grepl("Unknown", death_records[, mc]) |
-                   grepl("U", death_records[, mc]))
+      as.numeric(death_records[, mc] %in% unknown_responses)
     
     proportion <- calculate_proportion(
       death_records, 

--- a/code/R/proportion_with_incomplete_funeral_director_fields.R
+++ b/code/R/proportion_with_incomplete_funeral_director_fields.R
@@ -11,7 +11,9 @@ death_records <-
 
 # Define the funeral director columns
 funeral_director_columns <- c(
-  "Funeral Facility"
+  "Funeral Facility",
+  "FFF",
+  "AAAAA"
 )  # add or remove columns as needed
 
 # Define responses corresponding to "unknown"
@@ -21,16 +23,26 @@ unknown_responses <- c(
 )
 
 # Subset the funeral director columns to those that appear in the data
-funeral_director_columns <- 
-  funeral_director_columns[
-    funeral_director_columns %in% colnames(death_records)
-  ]
+if (any(!funeral_director_columns %in% colnames(death_records))){
+  cat(paste0(
+    "The following specified funeral director fields do not appear in the data: ",
+    paste(
+      funeral_director_columns[
+        !funeral_director_columns %in% colnames(death_records)
+      ], collapse = ", ")
+  ),
+  "\n")
+  funeral_director_columns <- 
+    funeral_director_columns[
+      funeral_director_columns %in% colnames(death_records)
+    ]
+}
 
 # Create a new column that is True when at least one funeral director field is empty or unknown
 death_records["Incomplete Funeral Director Fields"] =
   rowSums(
-    is.na(death_records[, funeral_director_columns]) | 
-      (death_records[, funeral_director_columns]  %in% unknown_responses)
+    is.na(death_records[, funeral_director_columns, drop = F]) | 
+      (death_records[, funeral_director_columns, drop = F] %in% unknown_responses)
   ) > 0
 
 # Calculate the proportion of records with incomplete funeral director fields

--- a/code/R/proportion_with_incomplete_funeral_director_fields.R
+++ b/code/R/proportion_with_incomplete_funeral_director_fields.R
@@ -1,0 +1,37 @@
+# Load necessary libraries
+library(here)
+
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
+
+# Load the death records data
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
+
+
+# Define the funeral director columns
+funeral_director_columns = c(
+  "Funeral Facility"
+)  # add or remove columns as needed
+
+# Subset the funeral director columns to those that appear in the data
+funeral_director_columns <- 
+  funeral_director_columns[
+    funeral_director_columns %in% colnames(death_records)
+  ]
+
+# Create a new column that is True when at least one funeral director field is empty or unknown
+death_records["Incomplete Funeral Director Fields"] =
+  rowSums(
+    is.na(death_records[, funeral_director_columns, drop = F]) | 
+      (death_records[, funeral_director_columns, drop = F] == "Unknown")
+  ) > 0
+
+# Calculate the proportion of records with incomplete funeral director fields
+proportion <- calculate_proportion(
+  death_records, 
+  metric = "Incomplete Funeral Director Fields",
+  metric_description = "at least one funeral director field incomplete"
+)
+

--- a/code/R/proportion_with_incomplete_funeral_director_fields.R
+++ b/code/R/proportion_with_incomplete_funeral_director_fields.R
@@ -11,9 +11,7 @@ death_records <-
 
 # Define the funeral director columns
 funeral_director_columns <- c(
-  "Funeral Facility",
-  "FFF",
-  "AAAAA"
+  "Funeral Facility"
 )  # add or remove columns as needed
 
 # Define responses corresponding to "unknown"

--- a/code/R/proportion_with_incomplete_funeral_director_fields.R
+++ b/code/R/proportion_with_incomplete_funeral_director_fields.R
@@ -9,9 +9,8 @@ file_path <- here::here("data", "SyntheticDeathRecordData.csv")
 death_records <- 
   load_death_records(file_path)
 
-
 # Define the funeral director columns
-funeral_director_columns = c(
+funeral_director_columns <- c(
   "Funeral Facility"
 )  # add or remove columns as needed
 

--- a/code/R/proportion_with_incomplete_funeral_director_fields.R
+++ b/code/R/proportion_with_incomplete_funeral_director_fields.R
@@ -47,6 +47,7 @@ death_records["Incomplete Funeral Director Fields"] =
 proportion <- calculate_proportion(
   death_records, 
   metric = "Incomplete Funeral Director Fields",
-  metric_description = "at least one funeral director field incomplete"
+  metric_description = "at least one funeral director field incomplete", 
+  print_output = TRUE
 )
 

--- a/code/R/proportion_with_incomplete_funeral_director_fields.R
+++ b/code/R/proportion_with_incomplete_funeral_director_fields.R
@@ -14,6 +14,12 @@ funeral_director_columns <- c(
   "Funeral Facility"
 )  # add or remove columns as needed
 
+# Define responses corresponding to "unknown"
+unknown_responses <- c(
+  "Unknown",
+  "U"
+)
+
 # Subset the funeral director columns to those that appear in the data
 funeral_director_columns <- 
   funeral_director_columns[
@@ -23,8 +29,8 @@ funeral_director_columns <-
 # Create a new column that is True when at least one funeral director field is empty or unknown
 death_records["Incomplete Funeral Director Fields"] =
   rowSums(
-    is.na(death_records[, funeral_director_columns, drop = F]) | 
-      (death_records[, funeral_director_columns, drop = F] == "Unknown")
+    is.na(death_records[, funeral_director_columns]) | 
+      (death_records[, funeral_director_columns]  %in% unknown_responses)
   ) > 0
 
 # Calculate the proportion of records with incomplete funeral director fields

--- a/code/R/proportion_with_incomplete_medical_certifier_fields.R
+++ b/code/R/proportion_with_incomplete_medical_certifier_fields.R
@@ -57,6 +57,7 @@ death_records["Incomplete Medical Certifier Fields"] =
 proportion <- calculate_proportion(
   death_records, 
   metric = "Incomplete Medical Certifier Fields",
-  metric_description = "at least one medical certifier field incomplete"
+  metric_description = "at least one medical certifier field incomplete", 
+  print_output = TRUE
 )
 

--- a/code/R/proportion_with_incomplete_medical_certifier_fields.R
+++ b/code/R/proportion_with_incomplete_medical_certifier_fields.R
@@ -1,0 +1,46 @@
+# Load necessary libraries
+library(here)
+
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
+
+# Load the death records data
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
+
+# Define the medical columns
+medical_columns <- c(
+  "Tobacco Use Contributed to Death",
+  "Date Certified",
+  "Certifier Type"
+)  # add or remove columns as needed
+# Additionally, define column for sex and pregnancy columns in the data
+sex_column <- "Sex"
+pregancy_column <- "Pregnancy Status"
+
+# Subset the medical columns to those that appear in the data
+medical_columns <- 
+  medical_columns[
+    medical_columns %in% colnames(death_records)
+  ]
+
+# Create a column that's True when any medical certifier field is empty; special
+# case pregnancy status since it only applies to female decedents
+death_records["Incomplete Medical Certifier Fields"] =
+  rowSums(
+    (death_records[, sex_column] == "F" & (
+      is.na(death_records[, pregancy_column]) |
+        death_records[, pregancy_column] == "Unknown"
+    )) |
+      is.na(death_records[, medical_columns, drop = F]) | 
+      (death_records[, medical_columns, drop = F] == "Unknown")
+  ) > 0
+
+# Calculate the proportion of records with incomplete funeral director fields
+proportion <- calculate_proportion(
+  death_records, 
+  metric = "Incomplete Medical Certifier Fields",
+  metric_description = "at least one medical certifier field incomplete"
+)
+

--- a/code/R/proportion_with_incomplete_medical_certifier_fields.R
+++ b/code/R/proportion_with_incomplete_medical_certifier_fields.R
@@ -26,21 +26,31 @@ unknown_responses <- c(
 )
 
 # Subset the medical columns to those that appear in the data
-medical_columns <- 
-  medical_columns[
-    medical_columns %in% colnames(death_records)
-  ]
+if (any(!medical_columns %in% colnames(death_records))){
+  cat(paste0(
+    "The following specified medical fields do not appear in the data: ",
+    paste(
+      medical_columns[
+        !medical_columns %in% colnames(death_records)
+      ], collapse = ", ")
+  ),
+  "\n")
+  medical_columns <- 
+    medical_columns[
+      medical_columns %in% colnames(death_records)
+    ]
+}
 
 # Create a column that's True when any medical certifier field is empty; special
 # case pregnancy status since it only applies to female decedents
 death_records["Incomplete Medical Certifier Fields"] =
+  (death_records[, sex_column, drop = F] == "F" & (
+    is.na(death_records[, pregancy_column, drop = F]) |
+      death_records[, pregancy_column, drop = F] %in% unknown_responses
+  )) |
   rowSums(
-    (death_records[, sex_column] == "F" & (
-      is.na(death_records[, pregancy_column]) |
-        death_records[, pregancy_column] %in% unknown_responses
-    )) |
-      is.na(death_records[, medical_columns]) | 
-      (death_records[, medical_columns] %in% unknown_responses)
+    is.na(death_records[, medical_columns, drop = F]) | 
+      (death_records[, medical_columns, drop = F] %in% unknown_responses)
   ) > 0
 
 # Calculate the proportion of records with incomplete funeral director fields

--- a/code/R/proportion_with_incomplete_medical_certifier_fields.R
+++ b/code/R/proportion_with_incomplete_medical_certifier_fields.R
@@ -19,6 +19,12 @@ medical_columns <- c(
 sex_column <- "Sex"
 pregancy_column <- "Pregnancy Status"
 
+# Define responses corresponding to "unknown"
+unknown_responses <- c(
+  "Unknown",
+  "U"
+)
+
 # Subset the medical columns to those that appear in the data
 medical_columns <- 
   medical_columns[
@@ -31,10 +37,10 @@ death_records["Incomplete Medical Certifier Fields"] =
   rowSums(
     (death_records[, sex_column] == "F" & (
       is.na(death_records[, pregancy_column]) |
-        death_records[, pregancy_column] == "Unknown"
+        death_records[, pregancy_column] %in% unknown_responses
     )) |
-      is.na(death_records[, medical_columns, drop = F]) | 
-      (death_records[, medical_columns, drop = F] == "Unknown")
+      is.na(death_records[, medical_columns]) | 
+      (death_records[, medical_columns] %in% unknown_responses)
   ) > 0
 
 # Calculate the proportion of records with incomplete funeral director fields

--- a/code/R/proportion_with_one_cause.R
+++ b/code/R/proportion_with_one_cause.R
@@ -19,12 +19,14 @@ death_records[, "Single Record Axis COD"] <-
 proportion <- calculate_proportion(
   death_records, 
   metric = "Single Record Axis COD",
-  metric_description = "Single Record Axis COD"
+  metric_description = "Single Record Axis COD", 
+  print_output = TRUE
 )
 
 # Group the records by certifier and calculate the proportion of flagged records for each certifier
 certifier_proportions <- calculate_proportion_by_column(
   death_records, 
   metric = "Single Record Axis COD",
-  column = "Certifier Name"
+  column = "Certifier Name", 
+  print_output = TRUE
 )

--- a/code/R/proportion_with_one_cause.R
+++ b/code/R/proportion_with_one_cause.R
@@ -26,6 +26,5 @@ proportion <- calculate_proportion(
 certifier_proportions <- calculate_proportion_by_column(
   death_records, 
   metric = "Single Record Axis COD",
-  metric_description = "Single Record Axis COD",
   column = "Certifier Name"
 )

--- a/code/R/proportion_with_one_cause.R
+++ b/code/R/proportion_with_one_cause.R
@@ -1,16 +1,13 @@
 # Load necessary libraries
 library(here)
 
-# Specify the relative path to the data location
-data_path <- here::here("data")
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
 
 # Load the death records data
-death_records <- read.csv(
-  file.path(data_path, "SyntheticDeathRecordData.csv"),
-  stringsAsFactors = FALSE,
-  check.names = FALSE,
-  na.strings = ""
-)
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
 
 # Create a new column that is True when a single Record Axis COD column is populated
 death_records[, "Single Record Axis COD"] <-
@@ -19,23 +16,16 @@ death_records[, "Single Record Axis COD"] <-
   ) == 1
 
 # Calculate the proportion of records with only one Record Axis COD
-proportion <- mean(death_records$`Single Record Axis COD`, na.rm = TRUE)
-
-cat(paste("The proportion of records with a single Record Axis COD is",
-          round(proportion, 2), "\n"))
+proportion <- calculate_proportion(
+  death_records, 
+  metric = "Single Record Axis COD",
+  metric_description = "Single Record Axis COD"
+)
 
 # Group the records by certifier and calculate the proportion of flagged records for each certifier
-certifier_proportions <- 
-  aggregate(
-    list("Proportion" = death_records$`Single Record Axis COD`),
-    list("Certifier Name" = death_records$`Certifier Name`),
-    FUN = mean,
-    na.rm = TRUE)
-
-# Print the proportions for each certifier
-for(i in 1:nrow(certifier_proportions)) {
-  cat(paste("The proportion of records with a single Record Axis COD provided by",
-            certifier_proportions[i, "Certifier Name"],
-            "is",
-            round(certifier_proportions[i, "Proportion"], 2), "\n"))
-}
+certifier_proportions <- calculate_proportion_by_column(
+  death_records, 
+  metric = "Single Record Axis COD",
+  metric_description = "Single Record Axis COD",
+  column = "Certifier Name"
+)

--- a/code/R/proportion_with_unsuitable_underlying.R
+++ b/code/R/proportion_with_unsuitable_underlying.R
@@ -34,6 +34,5 @@ proportion <- calculate_proportion(
 certifier_proportions <- calculate_proportion_by_column(
   death_records, 
   metric = "Unsuitable Underlying",
-  metric_description = "unsuitable underlying cause of death",
   column = "Certifier Name"
 )

--- a/code/R/proportion_with_unsuitable_underlying.R
+++ b/code/R/proportion_with_unsuitable_underlying.R
@@ -27,12 +27,14 @@ death_records[, "Unsuitable Underlying"] <- sapply(
 proportion <- calculate_proportion(
   death_records, 
   metric = "Unsuitable Underlying",
-  metric_description = "unsuitable underlying cause of death"
+  metric_description = "unsuitable underlying cause of death", 
+  print_output = TRUE
 )
 
 # Group the records by certifier and calculate the proportion of unsuitable records for each certifier
 certifier_proportions <- calculate_proportion_by_column(
   death_records, 
   metric = "Unsuitable Underlying",
-  column = "Certifier Name"
+  column = "Certifier Name", 
+  print_output = TRUE
 )

--- a/code/R/proportion_with_unsuitable_underlying.R
+++ b/code/R/proportion_with_unsuitable_underlying.R
@@ -1,19 +1,16 @@
 # Load necessary libraries
 library(here)
 
-# Specify the relative path to the data location
-data_path <- here::here("data")
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
 
 # Load the death records data
-death_records <- read.csv(
-  file.path(data_path, "SyntheticDeathRecordData.csv"),
-  stringsAsFactors = FALSE,
-  check.names = FALSE,
-  na.strings = ""
-)
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
 
 # Load the unsuitable causes of death data
-unsuitable_causes <- read.csv(file.path(data_path, "unsuitable_COD_codes.csv"))
+unsuitable_causes <- read.csv(here::here("data", "unsuitable_COD_codes.csv"))
 
 # Extract the unsuitable codes
 unsuitable_codes <- unsuitable_causes$code
@@ -27,24 +24,16 @@ death_records[, "Unsuitable Underlying"] <- sapply(
 )
 
 # Calculate the proportion of records with an unsuitable underlying cause of death
-proportion <- mean(death_records$`Unsuitable Underlying`, na.rm = TRUE)
-
-cat(paste("The proportion of records with an unsuitable underlying cause of death is",
-          round(proportion, 2),
-          "\n"))
+proportion <- calculate_proportion(
+  death_records, 
+  metric = "Unsuitable Underlying",
+  metric_description = "unsuitable underlying cause of death"
+)
 
 # Group the records by certifier and calculate the proportion of unsuitable records for each certifier
-certifier_proportions <- 
-  aggregate(
-    list("Proportion" = death_records$`Unsuitable Underlying`),
-    list("Certifier Name" = death_records$`Certifier Name`),
-    FUN = mean,
-    na.rm = TRUE)
-
-# Print the proportions for each certifier
-for(i in 1:nrow(certifier_proportions)) {
-  cat(paste("The proportion of records with an unsuitable underlying cause of death provided by",
-            certifier_proportions[i, "Certifier Name"],
-            "is",
-            round(certifier_proportions[i, "Proportion"], 2), "\n"))
-}
+certifier_proportions <- calculate_proportion_by_column(
+  death_records, 
+  metric = "Unsuitable Underlying",
+  metric_description = "unsuitable underlying cause of death",
+  column = "Certifier Name"
+)

--- a/code/R_notebook/MortalityDataQualityAssessment.Rmd
+++ b/code/R_notebook/MortalityDataQualityAssessment.Rmd
@@ -18,25 +18,23 @@ The following code demonstrates how mortality records can be evaluated against a
 We start by loading necessary libraries for processing, as well as our data:
 
 ```{r}
+# Load necessary libraries
 library(here)
 
-# Specify the relative path to the data location
-data_path <- here::here("data")
+# Load supporting functions
+source(here::here("code", "R", "dqaf_metrics.R"))
 
 # Load the death records data
-death_records <- read.csv(
-  file.path(data_path, "SyntheticDeathRecordData.csv"),
-  stringsAsFactors = FALSE,
-  check.names = FALSE,
-  na.strings = ""
-)
+file_path <- here::here("data", "SyntheticDeathRecordData.csv")
+death_records <- 
+  load_death_records(file_path)
 ```
 
 Then we calculate which causes of death in our data are unsuitable:
 
 ```{r}
 # Load the unsuitable causes of death data
-unsuitable_causes <- read.csv(file.path(data_path, "unsuitable_COD_codes.csv"))
+unsuitable_causes <- read.csv(here::here("data", "unsuitable_COD_codes.csv"))
 
 # Extract the unsuitable codes
 unsuitable_codes <- unsuitable_causes$code
@@ -54,31 +52,23 @@ How many records have an unsuitable cause of death?
 
 ```{r}
 # Calculate the proportion of records with an unsuitable underlying cause of death
-proportion <- mean(death_records$`Unsuitable Underlying`, na.rm = TRUE)
-
-cat(paste("The proportion of records with an unsuitable underlying cause of death is",
-          round(proportion, 2),
-          "\n"))
+proportion <- calculate_proportion(
+  death_records, 
+  metric = "Unsuitable Underlying",
+  metric_description = "unsuitable underlying cause of death"
+)
 ```
 
 Let's examine the records with unsuitable cause of death by certifier:
 
 ```{r}
 # Group the records by certifier and calculate the proportion of unsuitable records for each certifier
-certifier_proportions <- 
-  aggregate(
-    list("Proportion" = death_records$`Unsuitable Underlying`),
-    list("Certifier Name" = death_records$`Certifier Name`),
-    FUN = mean,
-    na.rm = TRUE)
-
-# Print the proportions for each certifier
-for(i in 1:nrow(certifier_proportions)) {
-  cat(paste("The proportion of records with an unsuitable underlying cause of death provided by",
-            certifier_proportions[i, "Certifier Name"],
-            "is",
-            round(certifier_proportions[i, "Proportion"], 2), "\n"))
-}
+certifier_proportions <- calculate_proportion_by_column(
+  death_records, 
+  metric = "Unsuitable Underlying",
+  metric_description = "unsuitable underlying cause of death",
+  column = "Certifier Name"
+)
 ```
 
 Let's visualize that using ggplot to see the certifiers with the highest proportion of unsuitable records:

--- a/code/python/dqaf_metrics.py
+++ b/code/python/dqaf_metrics.py
@@ -1,28 +1,37 @@
 import sys
 import pandas as pd
 
-death_records = None
-
 # Use supplied path to records and load as a pandas dataframe
-if len(sys.argv) > 1:
-    filename = sys.argv[1]
+def load_death_records(filename):
     try:
         death_records = pd.read_csv(filename, keep_default_na=False, na_values=[""])
     except FileNotFoundError:
         print(f"Error: File '{filename}' not found.")
     except Exception as e:
         print(f"An error occurred: {e}")
-else:
-    print(f"Usage: {sys.argv[0]} <filename>")
-    exit()
+    
+    return death_records
 
 # Calculate the overall proportion of the provided metric on the records we loaded above
-def proportion(metric):
+def calculate_proportion(death_records, metric, metric_description, print_output = True):
     death_records["Results Column"] = metric(death_records)
-    return death_records["Results Column"].mean()
+    proportion = death_records["Results Column"].mean()
+    
+    if print_output:
+      print(
+        f"The proportion of records with {metric_description} is {proportion:.2f}"
+      )
+    
+    return proportion
 
 # Calculate the proportion of the provided metric for each distinct value in supplied column
-def proportion_by_column(metric, column):
+def proportion_by_column(death_records, metric, column, print_output = True):
     death_records["Results Column"] = metric(death_records)
+    
+    col_proportions = death_records.groupby(column)["Results Column"].mean().reset_index(name="Proportion").sort_values(by="Proportion", ascending=False)
     #return list(death_records.groupby(column)["Results Column"].mean().items())
-    return death_records.groupby(column)["Results Column"].mean().reset_index(name="Proportion").sort_values(by="Proportion", ascending=False)
+    
+    if print_output:
+      print(col_proportions)
+    
+    return col_proportions

--- a/code/python/proportion_with_one_cause.py
+++ b/code/python/proportion_with_one_cause.py
@@ -1,4 +1,13 @@
 import dqaf_metrics
+import os
+
+# Locate the relative path to the data location
+data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "data")
+
+# Load the death record data
+death_records = dqaf_metrics.load_death_records(
+  os.path.join(data_path, "SyntheticDeathRecordData.csv")
+)
 
 # Define metric
 def metric(records):
@@ -8,14 +17,14 @@ def metric(records):
     # Return a column that is True when a single Record Axis COD column is populated
     return records[record_axis_cod_columns].notna().sum(axis=1) == 1
 
-description = "The proportion of records with a single Record Axis COD"
-
 # Use metric to calculate overall proportion 
-proportion = dqaf_metrics.proportion(metric)
-print(f"{description} is {proportion:.2f}")
+proportion = dqaf_metrics.calculate_proportion(
+  death_records, metric, "Single Record Axis COD", True
+)
+
+print("")
 
 # Use metric to calculate proportion for each certifier
-proportion_by_certifier = dqaf_metrics.proportion_by_column(metric, "Certifier Name")
-# TODO: Update to use tabular output
-for certifier, proportion in proportion_by_certifier:
-    print(f"{description} provided by {certifier} is {proportion:.2f}")
+proportion_by_certifier = dqaf_metrics.proportion_by_column(
+  death_records, metric, "Certifier Name", True
+)

--- a/code/python/proportion_with_unsuitable_underlying.py
+++ b/code/python/proportion_with_unsuitable_underlying.py
@@ -5,6 +5,11 @@ import pandas as pd
 # Locate the relative path to the data location
 data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "data")
 
+# Load the death record data
+death_records = dqaf_metrics.load_death_records(
+  os.path.join(data_path, "SyntheticDeathRecordData.csv")
+)
+
 # Load the unsuitable causes of death data and extract codes
 unsuitable_causes = pd.read_csv(os.path.join(data_path, "unsuitable_COD_codes.csv"))
 unsuitable_codes = unsuitable_causes["code"].values
@@ -19,13 +24,14 @@ def metric(records):
     # Jurisdictions: update the column name from "Underlying COD" to match your data
     return records["Underlying COD"].apply(is_unsuitable)
 
-description = "Proportion of records with an unsuitable underlying cause of death"
-
 # Use metric to calculate overall proportion 
-proportion = dqaf_metrics.proportion(metric)
-print(f"{description}: {proportion:.2f}\n")
+proportion = dqaf_metrics.calculate_proportion(
+  death_records, metric, "unsuitable underlying cause of death", True
+)
+
+print("")
 
 # Use metric to calculate proportion for each certifier
-proportion_by_certifier = dqaf_metrics.proportion_by_column(metric, "Certifier Name")
-print(f"{description} by certifier:\n")
-print(proportion_by_certifier.to_string(index=False))
+proportion_by_certifier = dqaf_metrics.proportion_by_column(
+  death_records, metric, "Certifier Name", True
+)


### PR DESCRIPTION
This set of fixes does the following:
- creates a "common code" set for R similar to that in Python
- create R versions of all scripts in python
- adds in missingness customizability

Some changes from python:
- For the common code, I ingested the print statements within them as well -- since the root functions are one-liners, it didn't make sense to abstract them on their own, and we have to do these print statements throughout the scripts.
- For the incomplete medical certifier/funeral director scripts, I added a check for columns not appearing in the data, since I thought that might be prudent
- Since I'm adding the customizability for unknown responses, I made it do exact checks, rather than partial checks, since they're specifying the exact phrase